### PR TITLE
fix: unable to enter deep sleep

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,6 +142,7 @@ void lvglHandlerTask(void* parameter) {
                         Serial.println("Simultaneous CENTER and DOWN hold for 2s detected. Entering deep sleep.");
                         // Optional: Turn off display backlight or other peripherals before sleep
                         // displayInterface->setBacklight(0); // Example if such a function exists
+			esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_GPIO);
                         esp_deep_sleep_start();
                     }
                 }


### PR DESCRIPTION
This should resolve #53, which was introduced in ac00d0e3d88a9c5b44f129bc855423f3b80226e3.

What I believe was happening was the GPIO pins set as the wakeup source for light sleep [here in main.ccp](https://github.com/PostHog/DeskHog/blob/9f1887f5b082c2091d8214ce181e0ad8e9bae80c/src/main.cpp#L272C5-L275C36) were interrupting the device from entering deep sleep. Removing them as a wake source allows the device to sleep correctly.

The docs don't especially talk about how light and deep sleep interact (mostly talking about this [Sleep Modes - ESP32](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/sleep_modes.html) page), but this fix seems to work. Flashed and tested on my own DeskHog.

Since the RST button is used to wake the esp, the GPIO buttons should be rebound for waking from light sleep.