### PR TITLE
fix: navigation buttons stop working when "Hello World" card is selected

### DIFF
--- a/src/ui/examples/HelloWorldCard.cpp
+++ b/src/ui/examples/HelloWorldCard.cpp
@@ -1,5 +1,6 @@
 #include "ui/examples/HelloWorldCard.h"
 #include "Style.h"
+#include "hardware/Input.h"
 
 HelloWorldCard::HelloWorldCard(lv_obj_t* parent) : _card(nullptr), _label(nullptr) {
     _card = lv_obj_create(parent); // Create the card container
@@ -14,20 +15,25 @@ HelloWorldCard::HelloWorldCard(lv_obj_t* parent) : _card(nullptr), _label(nullpt
 }
 
 bool HelloWorldCard::handleButtonPress(uint8_t button_index) {
-    // Toggle between black and white backgrounds
-    static bool isBlack = true;
-    
-    if (isBlack) {
-        lv_obj_set_style_bg_color(_card, lv_color_white(), 0);
-        lv_obj_set_style_text_color(_label, lv_color_black(), 0);
-    } else {
-        lv_obj_set_style_bg_color(_card, lv_color_black(), 0);
-        lv_obj_set_style_text_color(_label, lv_color_white(), 0);
+    // only the center button should do anything here
+    if (button_index == Input::BUTTON_CENTER) {
+        // Toggle between black and white backgrounds
+        static bool isBlack = true;
+
+        if (isBlack) {
+            lv_obj_set_style_bg_color(_card, lv_color_white(), 0);
+            lv_obj_set_style_text_color(_label, lv_color_black(), 0);
+        } else {
+            lv_obj_set_style_bg_color(_card, lv_color_black(), 0);
+            lv_obj_set_style_text_color(_label, lv_color_white(), 0);
+        }
+
+        isBlack = !isBlack; // Toggle the state
+
+        return true; // We handled the button press
     }
-    
-    isBlack = !isBlack; // Toggle the state
-    
-    return true; // We handled the button press
+
+    return false; // let CardNavigationStack handle navigation buttons
 }
 
 HelloWorldCard::~HelloWorldCard() {


### PR DESCRIPTION
It looks like 93c996f reworked how the button presses are handled so that games can use all three GPIO buttons. However, the Hello World card was capturing all those events, so it was impossible to exit the card without resetting the device.

This is how other cards like the Friend Card handle it fwiw [code](https://github.com/PostHog/DeskHog/blob/9f1887f5b082c2091d8214ce181e0ad8e9bae80c/src/ui/FriendCard.cpp#L166C1-L175C2).