### PR TITLE
fix: attempt to fix ota by fixing task timer & github api call

### DIFF
--- a/src/OtaManager.cpp
+++ b/src/OtaManager.cpp
@@ -96,7 +96,7 @@ OtaManager::OtaManager(const String& currentVersion, const String& repoOwner, co
         .idle_core_mask = (1 << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
         .trigger_panic = true
     };
-    ESP_ERROR_CHECK(esp_task_wdt_init(&twdt_config_update));
+    ESP_ERROR_CHECK(esp_task_wdt_reconfigure(&twdt_config_update));
 
     _dataMutex = xSemaphoreCreateMutex();
     if (_dataMutex == NULL) {


### PR DESCRIPTION
Left some reasoning in #63. 

A few different elements here:

1. The watchdog timer was initialized multiple times in `OtaManager.cpp` with `esp_task_wdt_init`, which, because those calls were wrapped with `ESP_ERROR_CHECK`, caused the kernel to panic because the watchdog timer initialization call returns an error when the timer is already initialized. I've generally only seen this panic happen when checking for updates right after boot.
2. The watchdog timer is actually already automatically initialized on boot by default ([source](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig-reference.html#config-esp-task-wdt-en)), so passing the `esp_task_wdt_config_t` had no effect, the watchdog timer timeout was still it's default of 5 seconds ([source](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig-reference.html#config-esp-task-wdt-timeout-s)), not the intended 30 seconds. 
3. Trying to fix `No_Memory` error on update check, which is a separate issue from the kernel panics. Using the `/latest` route in the github API seems to fix this. I'm not 100% sure what caused this, but I haven't gotten that error since changing the route. My working theory is that as more releases were published, it was too much data for the json parser to handle for some reason.


(sorry about big whitespace diff)