### PR TITLE
chore: pin github actions to commit shas

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.11'
     
@@ -81,7 +81,7 @@ jobs:
         echo "esptool.py --chip esp32s3 --port /dev/ttyUSB0 --baud 1500000 write_flash -z 0x0 deskhog-bootloader-${{ steps.get_version.outputs.VERSION }}.bin 0x8000 deskhog-partitions-${{ steps.get_version.outputs.VERSION }}.bin 0x10000 deskhog-firmware-${{ steps.get_version.outputs.VERSION }}.bin" > release/flash-command.txt
     
     - name: Upload all build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: firmware-complete-${{ steps.get_version.outputs.VERSION }}
         path: release/
@@ -90,7 +90,7 @@ jobs:
       if: github.event_name == 'release'
       permissions:
         contents: write
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       with:
         files: |
           release/firmware.bin

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,10 +30,10 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -50,6 +50,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Pins actions in .github/workflows to commit SHAs via pinact. Generated by multi-gitter.